### PR TITLE
Log error when running session that doesn't exist.

### DIFF
--- a/nox/main.py
+++ b/nox/main.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 import argparse
 import imp
 from inspect import isfunction
+import itertools
 import os
 import sys
 
@@ -87,6 +88,13 @@ def run(global_config):
         sessions = [x for x in sessions if (
             x.name in global_config.sessions or
             x.signature in global_config.sessions)]
+        missing_sessions = set(global_config.sessions) - set(
+            itertools.chain(
+                [x.name for x in sessions if x.name],
+                [x.signature for x in sessions if x.signature]))
+        if missing_sessions:
+            logger.error('Sessions {} not found.'.format(missing_sessions))
+            return False
 
     success = True
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -277,6 +277,19 @@ def test_run(monkeypatch, capsys):
         assert sessions[1].execute.called is True
         assert sessions[2].execute.called is False
 
+        for session in sessions:
+            session.execute.reset_mock()
+
+        # Calling a signature that does not exist should not call any version.
+        global_config.sessions = ['a(1)', 'a(3)', 'b']
+
+        result = nox.main.run(global_config)
+        assert not result
+
+        assert sessions[0].execute.called is False
+        assert sessions[1].execute.called is False
+        assert sessions[2].execute.called is False
+
 
 def test_run_file_not_found():
     global_config = Namespace(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -234,6 +234,19 @@ def test_run(monkeypatch, capsys):
         for session in sessions:
             session.execute.reset_mock()
 
+        # Try to run with a session that doesn't exist.
+        global_config.sessions = ['1', 'doesntexist']
+
+        result = nox.main.run(global_config)
+        assert not result
+
+        assert sessions[0].execute.called is False
+        assert sessions[1].execute.called is False
+        assert sessions[2].execute.called is False
+
+        for session in sessions:
+            session.execute.reset_mock()
+
         # Now we'll try with parametrized sessions. Calling the basename
         # should execute all parametrized versions.
         sessions[0].name = 'a'


### PR DESCRIPTION
I found it difficult to get the escaping correct for parameterized
sessions. By returning an error I was able to debug this more easily.
(Also prevents me from thinking that I'm running tests when I'm actually
not.)