### PR TITLE
Properly transform interpreter on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,10 +13,12 @@ environment:
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.11"
       PYTHON_ARCH: "32"
+      NOX_ENV: "interpreters(version='2.7')"
 
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.11"
       PYTHON_ARCH: "64"
+      NOX_ENV: "interpreters(version='2.7')"
 
     # Python 3.4.4 is the latest Python 3.4 with a Windows installer
     # Python 3.4.4 is the overall latest
@@ -24,10 +26,12 @@ environment:
     - PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.4.4"
       PYTHON_ARCH: "32"
+      NOX_ENV: "interpreters(version='3.4')"
 
     - PYTHON: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4.4"
       PYTHON_ARCH: "64"
+      NOX_ENV: "interpreters(version='3.4')"
 
     # Python 3.5.1 is the latest Python 3.5 with a Windows installer
     # Python 3.5.1 is the overall latest
@@ -35,10 +39,12 @@ environment:
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.1"
       PYTHON_ARCH: "32"
+      NOX_ENV: "interpreters(version='3.5')"
 
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.1"
       PYTHON_ARCH: "64"
+      NOX_ENV: "interpreters(version='3.5')"
 
 install:
   # Install Python (from the official .msi of http://python.org) and pip when
@@ -76,3 +82,4 @@ build_script:
 test_script:
   # Run the project tests
   - "nox.exe --session default"
+  - "nox.exe --session \"%NOX_ENV%\""

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,12 +13,12 @@ environment:
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.11"
       PYTHON_ARCH: "32"
-      NOX_ENV: "interpreters(version='2.7')"
+      NOX_SESSION: "interpreters(version='2.7')"
 
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.11"
       PYTHON_ARCH: "64"
-      NOX_ENV: "interpreters(version='2.7')"
+      NOX_SESSION: "interpreters(version='2.7')"
 
     # Python 3.4.4 is the latest Python 3.4 with a Windows installer
     # Python 3.4.4 is the overall latest
@@ -26,12 +26,12 @@ environment:
     - PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.4.4"
       PYTHON_ARCH: "32"
-      NOX_ENV: "interpreters(version='3.4')"
+      NOX_SESSION: "interpreters(version='3.4')"
 
     - PYTHON: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4.4"
       PYTHON_ARCH: "64"
-      NOX_ENV: "interpreters(version='3.4')"
+      NOX_SESSION: "interpreters(version='3.4')"
 
     # Python 3.5.1 is the latest Python 3.5 with a Windows installer
     # Python 3.5.1 is the overall latest
@@ -39,12 +39,12 @@ environment:
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.1"
       PYTHON_ARCH: "32"
-      NOX_ENV: "interpreters(version='3.5')"
+      NOX_SESSION: "interpreters(version='3.5')"
 
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.1"
       PYTHON_ARCH: "64"
-      NOX_ENV: "interpreters(version='3.5')"
+      NOX_SESSION: "interpreters(version='3.5')"
 
 install:
   # Install Python (from the official .msi of http://python.org) and pip when
@@ -82,4 +82,4 @@ build_script:
 test_script:
   # Run the project tests
   - "nox.exe --session default"
-  - "nox.exe --session \"%NOX_ENV%\""
+  - "nox.exe --session \"%NOX_SESSION%\""

--- a/nox/command.py
+++ b/nox/command.py
@@ -19,6 +19,8 @@ import sys
 
 from nox.logger import logger
 from nox.popen import popen
+from nox.utils import coerce_str
+
 import py
 import six
 
@@ -68,7 +70,9 @@ class Command(object):
 
         cmd_path = which(cmd, path)
 
-        # Environment variables must be bytestrings.
+        # Environment variables must be the "str" type.
+        # In other words, they must be bytestrings in Python 2, and Unicode
+        # text strings in Python 3.
         clean_env = {} if env is not None else None
         if clean_env is not None:
             # Ensure systemroot is passed down, otherwise Windows will explode.
@@ -76,10 +80,8 @@ class Command(object):
                 'SYSTEMROOT', str(''))
 
             for key, value in six.iteritems(env):
-                if not isinstance(key, six.text_type):
-                    key = key.decode('utf-8')
-                if not isinstance(value, six.text_type):
-                    value = value.decode('utf-8')
+                key = coerce_str(key)
+                value = coerce_str(value)
                 clean_env[key] = value
 
         try:

--- a/nox/utils.py
+++ b/nox/utils.py
@@ -1,0 +1,34 @@
+# Copyright 2017 Jon Wayne Parrott
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import six
+
+
+def coerce_str(maybe_str):
+    """Returns a str object, on both Python 2 and Python 3.
+
+    This means that Python 2 gets a bytes, and Python 3 gets a Unicode
+    text string.
+
+    This is what is expected for environment variables, where sending a
+    unicode on Python 2 or a bytes on Python 3 will raise an exception.
+    """
+    # If we already have a string, we are done.
+    if isinstance(maybe_str, str):
+        return maybe_str
+
+    # On Python 2, we got a unicode; on Python 3, we got a bytes.
+    if six.PY2:
+        return maybe_str.encode('utf-8')
+    return maybe_str.decode('utf-8')

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -99,7 +99,7 @@ class VirtualEnv(ProcessEnv):
                 r'c:\python{maj}{min}-x64\python.exe'.format(**version),
             )
             for path in potential_paths:
-                if py.path.local(path).check()
+                if py.path.local(path).check():
                     return str(path)
 
         # If we got this far, then we were unable to resolve the interpreter

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -77,7 +77,7 @@ class VirtualEnv(ProcessEnv):
         """
         # Sanity check: If there is no assigned interpreter, then
         # do nothing.
-        if not self.interpreter:
+        if self.interpreter is None:
             return self.interpreter
 
         # Sanity check: We only need special behavior on Windows.
@@ -99,8 +99,7 @@ class VirtualEnv(ProcessEnv):
                 r'c:\python{maj}{min}-x64\python.exe'.format(**version),
             )
             for path in potential_paths:
-                actual = py.path.local(path)
-                if actual.check():
+                if py.path.local(path).check()
                     return str(path)
 
         # If we got this far, then we were unable to resolve the interpreter

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -25,15 +25,16 @@ import pytest
 
 def test__normalize_path():
     envdir = 'envdir'
-    assert nox.sessions._normalize_path(envdir, u'hello') == 'envdir/hello'
-    assert nox.sessions._normalize_path(envdir, b'hello') == 'envdir/hello'
-    assert nox.sessions._normalize_path(
-        envdir, 'hello(world)') == 'envdir/hello-world'
-    assert nox.sessions._normalize_path(
-        envdir, 'hello(world, meep)') == 'envdir/hello-world-meep'
-    assert nox.sessions._normalize_path(
+    normalize = nox.sessions._normalize_path
+    assert normalize(envdir, u'hello') == os.path.join('envdir', 'hello')
+    assert normalize(envdir, b'hello') == os.path.join('envdir', 'hello')
+    assert normalize(envdir, 'hello(world)') == os.path.join(
+        'envdir', 'hello-world')
+    assert normalize(envdir, 'hello(world, meep)') == os.path.join(
+        'envdir', 'hello-world-meep')
+    assert normalize(
         envdir, 'tests(interpreter="python2.7", django="1.10")') == (
-        'envdir/tests-interpreter-python2-7-django-1-10')
+        os.path.join('envdir', 'tests-interpreter-python2-7-django-1-10'))
 
 
 def test__normalize_path_hash():
@@ -181,7 +182,8 @@ def test__create_config_auto_chdir(make_one):
     session._create_config()
     assert len(session.config._commands) == 1
     assert isinstance(session.config._commands[0], nox.command.ChdirCommand)
-    assert session.config._commands[0].path == '/path/to'
+    assert session.config._commands[0].path.endswith(
+        os.path.join('path', 'to'))
 
 
 class MockVenv(object):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,35 @@
+# Copyright 2017 Jon Wayne Parrott
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nox import utils
+
+
+def test_coerce_str_input_str():
+    # Establish that if given a literal str, coerce_str returns its input.
+    input_ = str('foo')
+    assert utils.coerce_str(input_) is input_
+
+
+def test_coerce_str_unicode():
+    input_ = u'foo'
+    output = utils.coerce_str(input_)
+    assert isinstance(output, str)
+    assert output == str('foo')
+
+
+def test_coerce_str_bytes():
+    input_ = b'foo'
+    output = utils.coerce_str(input_)
+    assert isinstance(output, str)
+    assert output == str('foo')


### PR DESCRIPTION
Once complete, this PR will properly transform a standard `pythonX.Y` interpreter designation to the appropriate standard path on Windows.

### Do not merge.

At the moment, this is a "thrash PR" because AppVeyor is what I am using to test work. It is not yet intended for merge

Additionally, test coverage is below 100%. I am trying to figure out what code works properly before I write tests.