### PR TITLE
Fix relative -f arguments.

### DIFF
--- a/nox/main.py
+++ b/nox/main.py
@@ -139,9 +139,17 @@ def create_report(report_filename, success, results):
 
 def run(global_config):
     try:
+        # Save the absolute path to the Noxfile.
+        # This will innoculate it if nox changes paths because of an implicit
+        # or explicit chdir (like the one below).
+        global_config.noxfile = os.path.realpath(global_config.noxfile)
+
+        # Move to the path where the Noxfile is.
+        # This will ensure that the Noxfile's path is on sys.path, and that
+        # import-time path resolutions work the way the Noxfile author would
+        # guess.
         os.chdir(os.path.realpath(os.path.dirname(global_config.noxfile)))
-        noxfile = global_config.noxfile.split(os.path.sep)[-1]
-        user_nox_module = load_user_nox_module(noxfile)
+        user_nox_module = load_user_nox_module(global_config.noxfile)
     except (IOError, OSError):
         logger.error('Noxfile {} not found.'.format(global_config.noxfile))
         return False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -239,7 +239,12 @@ def test_run(monkeypatch, capsys, tmpdir):
         result = nox.main.run(global_config)
         assert result
 
-        mock_load_user_module.assert_called_with('somefile.py')
+        # The `load_user_module` function receives an absolute path,
+        # but it ishould end with the noxfile argument.
+        mock_load_user_module.assert_called_once()
+        _, args, _ = mock_load_user_module.mock_calls[0]
+        assert args[0].endswith('somefile.py')
+
         mock_discover_session_functions.assert_called_with(user_nox_module)
         mock_make_sessions.assert_called_with(session_functions, global_config)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -240,7 +240,7 @@ def test_run(monkeypatch, capsys, tmpdir):
         assert result
 
         # The `load_user_module` function receives an absolute path,
-        # but it ishould end with the noxfile argument.
+        # but it should end with the noxfile argument.
         mock_load_user_module.assert_called_once()
         _, args, _ = mock_load_user_module.mock_calls[0]
         assert args[0].endswith('somefile.py')


### PR DESCRIPTION
This comment makes it such that the global_config.noxfile argument is made an absolute path early in the process, which should prevent more tricky relative path issues.

Fixes the bug I introduced in #14 and failed to fix in #19. This time I actually _tested_ it on `google-cloud-python`.