### PR TITLE
Adding --upgrade to "pip install" instructions.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ side of including lots of information, such as:
 Nox runs its own tests (it's recursive!). The best thing to do is start with
 a known-good nox installation, e.g. from PyPI:
 
-    pip install nox-automation
+    pip install --upgrade nox-automation
 
 To just check for lint errors, run:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ Welcome to Nox
 
 Install nox via `pip`_::
 
-    pip install nox-automation
+    pip install --upgrade nox-automation
 
 Nox is configured via a ``nox.py`` file in your project's directory. Here's a simple noxfile that runs lint and some tests::
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -9,7 +9,7 @@ Installation
 
 Nox can be easily installed via `pip`_::
 
-    pip install nox-automation
+    pip install --upgrade nox-automation
 
 Usually you install this globally, similar to ``tox``, ``pip``, and other similar tools.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -102,7 +102,7 @@ Nox has experimental support for converting ``tox.ini`` files into ``nox.py`` fi
 
 To use the converter, install ``nox`` with the ``tox-to-nox`` extra::
 
-    pip install nox[tox-to-nox]
+    pip install --upgrade nox-automation[tox-to-nox]
 
 Then, just run ``tox-to-nox`` in the directory where your ``tox.ini`` resides::
 


### PR DESCRIPTION
Also fixing a "typo" in the usage doc where the wrong PyPI package (`nox`) was referred to. Now:

```
pip install --upgrade nox-automation[tox-to-nox]
```