### PR TITLE
Fixing bad link in README (bad on PyPI).

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,11 +3,13 @@ Nox - Flexible test automation for Python
 
 |Build Status| |Coverage Status| |PyPI Version| |Docs|
 
-``nox`` is a command-line tool that automates testing in multiple Python environments, similar to `tox`_. Unlike tox, Nox uses a standard Python file for configuration.
+``nox`` is a command-line tool that automates testing in multiple Python
+environments, similar to `tox`_. Unlike tox, Nox uses a standard Python
+file for configuration.
 
-The latest documentation is available on `Read the Docs <docs>`_.
+The latest documentation is available on `Read the Docs`_.
 
-The source code is available on `GitHub <https://github.com/jonparrott/nox>`_.
+The source code is available on `GitHub`_.
 
 
 .. |Build Status| image:: https://travis-ci.org/jonparrott/nox.svg
@@ -19,4 +21,5 @@ The source code is available on `GitHub <https://github.com/jonparrott/nox>`_.
 .. |Docs| image:: https://readthedocs.org/projects/nox/badge/?version=latest
    :target: http://nox.readthedocs.org/en/latest/
 .. _tox: https://tox.readthedocs.org
-.. _docs: http://nox.readthedocs.org/en/latest/
+.. _Read the Docs: http://nox.readthedocs.org/en/latest/
+.. _GitHub: https://github.com/jonparrott/nox


### PR DESCRIPTION
Also managed to do some editorializing in the README :grinning: 

Currently the HTML generated [on PyPI][1] is:

```
<a href="docs" rel="nofollow">Read the Docs</a>
```

[1]: https://pypi.python.org/pypi/nox-automation/0.16.1