### PR TITLE
Refactor the list of sessions into a manifest class.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,11 @@ matrix:
     env: NOX_SESSION="interpreters(version='3.4')"
   - python: '3.5'
     env: NOX_SESSION="interpreters(version='3.5')"
-install: pip install codecov .
+  - python: '3.6'
+    env: NOX_SESSION="interpreters(version='3.6')"
+install:
+  - pip install --upgrade setuptools
+  - pip install codecov .
 script: nox --session "$NOX_SESSION"
 after_success: codecov
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,9 @@ matrix:
   - python: '3.6'
     env: NOX_SESSION="interpreters(version='3.6')"
 install:
-  - pip install --upgrade setuptools
-  - pip install codecov .
+  - pip install --upgrade pip setuptools
+  - pip install .
 script: nox --session "$NOX_SESSION"
-after_success: codecov
 deploy:
   provider: pypi
   user: jonparrott

--- a/nox/_testing.py
+++ b/nox/_testing.py
@@ -1,0 +1,19 @@
+# Copyright 2017 Jon Wayne Parrott
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class Namespace(object):
+    """A class that makes the provided kwargs available as attributes."""
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)

--- a/nox/main.py
+++ b/nox/main.py
@@ -127,7 +127,7 @@ def run(global_config):
     session_functions = discover_session_functions(user_nox_module)
     manifest = Manifest(session_functions, global_config)
 
-    # If the user just asked for a list of sessinos, print that
+    # If the user just asked for a list of sessions, print that
     # and be done.
     if global_config.list_sessions:
         print('Available sessions:')

--- a/nox/main.py
+++ b/nox/main.py
@@ -12,22 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+"""The nox `main` module.
+
+This is the entrypoint for the ``nox`` command (specifically, the ``main``
+function). This module primarily loads configuration, and then passes
+control to :meth:``nox.workflow.execute``.
+"""
+
+from __future__ import absolute_import, print_function
 
 import argparse
-import imp
-from inspect import isfunction
-import json
 import os
 import sys
 
 import pkg_resources
-from six import iterkeys
 
-from nox import registry
-from nox.logger import logger, setup_logging
-from nox.manifest import Manifest
-from nox.sessions import SessionStatus
+from nox import tasks
+from nox import workflow
+from nox.logger import setup_logging
 
 
 class GlobalConfig(object):
@@ -44,122 +46,6 @@ class GlobalConfig(object):
 
         if self.posargs and self.posargs[0] == '--':
             self.posargs.pop(0)
-
-
-def load_user_nox_module(module_file_name='nox.py'):
-    """Load the user's noxfile and return the module object for it."""
-    module = imp.load_source('user_nox_module', module_file_name)
-    return module
-
-
-def discover_session_functions(module):
-    """Discover all session functions in the noxfile module."""
-    # Find any function added to the session registry (meaning it was
-    # decorated with @nox.session); do not sort these, as they are being
-    # sorted by decorator call time.
-    funcs = registry.get()
-
-    # Find any function conforming to the session_* naming convention.
-    # Sort these in alphabetical order.
-    for name in sorted(iterkeys(module.__dict__)):
-        obj = module.__dict__[name]
-        if name.startswith('session_') and isfunction(obj):
-            session_name = name.split('session_', 1).pop()
-            funcs[session_name] = obj
-
-    # Return the final dictionary of session functions.
-    return funcs
-
-
-def print_summary(results):
-    logger.warning('Ran multiple sessions:')
-    for session, status in results:
-        if status == SessionStatus.SUCCESS:
-            log = logger.success
-            status = 'passed'
-        elif status == SessionStatus.SKIP:
-            log = logger.warning
-            status = 'skipped'
-        elif status == SessionStatus.FAIL:
-            log = logger.error
-            status = 'failed'
-        else:
-            raise ValueError('Unexpected session status: {}'.format(status))
-
-        log('* {}: {}'.format(
-            session.signature or session.name, status))
-
-
-def create_report(report_filename, status, results):
-    with open(report_filename, 'w') as report_file:
-        json.dump({
-            'result': status,
-            'sessions': [
-                {
-                    'name': session.name,
-                    'signature': session.signature,
-                    'result': result,
-                    'args': (
-                        session.func.call_spec
-                        if hasattr(session.func, 'call_spec') else {})
-                } for session, result in results
-            ]
-        }, report_file, indent=2)
-
-
-def run(global_config):
-    try:
-        # Save the absolute path to the Noxfile.
-        # This will innoculate it if nox changes paths because of an implicit
-        # or explicit chdir (like the one below).
-        global_config.noxfile = os.path.realpath(global_config.noxfile)
-
-        # Move to the path where the Noxfile is.
-        # This will ensure that the Noxfile's path is on sys.path, and that
-        # import-time path resolutions work the way the Noxfile author would
-        # guess.
-        os.chdir(os.path.realpath(os.path.dirname(global_config.noxfile)))
-        user_nox_module = load_user_nox_module(global_config.noxfile)
-    except (IOError, OSError):
-        logger.error('Noxfile {} not found.'.format(global_config.noxfile))
-        return False
-
-    session_functions = discover_session_functions(user_nox_module)
-    manifest = Manifest(session_functions, global_config)
-
-    # If the user just asked for a list of sessions, print that
-    # and be done.
-    if global_config.list_sessions:
-        print('Available sessions:')
-        for session in manifest:
-            print('*', session.signature or session.name)
-        return True
-
-    if not manifest:
-        return False
-
-    success = True
-    results = []
-
-    # Iterate over each session in the manifest, and execute it.
-    #
-    # Note that it is possible for the manifest to be altered in any given
-    # iteration.
-    for session in manifest:
-        result = session.execute()
-        results.append((session, result))
-        success = success and result
-        if not success and global_config.stop_on_first_error:
-            success = False
-            break
-
-    if len(results) > 1:
-        print_summary(results)
-
-    if global_config.report is not None:
-        create_report(global_config.report, success, results)
-
-    return success
 
 
 def main():
@@ -204,13 +90,20 @@ def main():
         return
 
     global_config = GlobalConfig(args)
-
     setup_logging()
 
-    try:
-        success = run(global_config)
-    except KeyboardInterrupt:
-        success = False
+    # Execute the appropriate tasks.
+    exit_code = workflow.execute(
+        global_config=global_config,
+        workflow=(
+            tasks.load_nox_module,
+            tasks.discover_manifest,
+            tasks.filter_manifest,
+            tasks.honor_list_request,
+            tasks.verify_manifest_nonempty,
+            tasks.run_manifest,
+        ),
+    )
 
-    if not success:
-        sys.exit(1)
+    # Done; exit.
+    sys.exit(exit_code)

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -24,16 +24,17 @@ from nox.sessions import Session
 class Manifest(object):
     """Session manifest.
 
-    The session manifest provides the final list of sessions that should be
-    run by nox.
+    The session manifest provides the source of truth for the sequence of
+    sessions that should be run by nox.
 
     It is possible for this to be mutated during execution. This allows for
-    useful use cases, such as for one session to "notify" another.
+    useful use cases, such as for one session to "notify" another or
+    "chain" to another.
 
     Args:
         session_functions (Mapping[str, function]): The registry of discovered
             session functions.
-        global_config (): The global configuration.
+        global_config (.nox.main.GlobalConfig): The global configuration.
     """
     def __init__(self, session_functions, global_config):
         self._all_sessions = []

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -1,0 +1,166 @@
+# Copyright 2017 Jon Wayne Parrott
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+import copy
+import itertools
+
+from nox._parametrize import generate_calls
+from nox.logger import logger
+from nox.sessions import Session
+
+
+class Manifest(object):
+    """Session manifest.
+
+    The session manifest provides the final list of sessions that should be
+    run by nox.
+
+    It is possible for this to be mutated during execution. This allows for
+    useful use cases, such as for one session to "notify" another.
+
+    Args:
+        session_functions (Mapping[str, function]): The registry of discovered
+            session functions.
+        global_config (): The global configuration.
+    """
+    def __init__(self, session_functions, global_config):
+        self._all_sessions = []
+        self._config = global_config
+
+        # Create the sessions based on the provided session functions.
+        for name, func in session_functions.items():
+            self.make_session(name, func)
+
+        # By default, every available session starts off in the queue.
+        self._queue = copy.copy(self._all_sessions)
+        self._consumed = []
+
+        # If the configuration specified filters, apply those now.
+        if self._config.sessions:
+            self.filter_by_name(self._config.sessions)
+        if self._config.keywords:
+            self.filter_by_keywords(self._config.keywords)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        """Return the next item in the queue.
+
+        Raises:
+            StopIteration: If the queue has been entirely consumed.
+        """
+        if not len(self._queue):
+            raise StopIteration
+        session = self._queue.pop(0)
+        self._consumed.append(session)
+        return session
+
+    def __nonzero__(self):
+        return bool(self._queue) or bool(self._consumed)
+
+    def filter_by_name(self, specified_sessions):
+        """Filter sessions in the queue based on the user-specified names.
+
+        Args:
+            specified_sessions (Sequence[str]): A list of specified
+                session names.
+        """
+        # Filter the sessions remaining in the queue based on
+        # whether they are individually specified.
+        self._queue = [x for x in self._queue if (
+            x.name in specified_sessions or
+            x.signature in specified_sessions)]
+
+        # If a session was requested and was not found, complain loudly.
+        missing_sessions = set(specified_sessions) - set(
+            itertools.chain(
+                [x.name for x in self._all_sessions if x.name],
+                [x.signature for x in self._all_sessions if x.signature]))
+        if missing_sessions:
+            logger.error('Sessions {} not found.'.format(', '.join(
+                missing_sessions)))
+            return False
+
+    def filter_by_keywords(self, keywords):
+        """Filter sessions using pytest-like keyword expressions.
+
+        Args:
+            keywords (Collection[str]): A collection of keywords which
+                session names are checked against.
+        """
+        self._queue = [
+            x for x in self._queue
+            if keyword_match(keywords, [x.signature or x.name])]
+
+    def make_session(self, name, func):
+        """Create a session object from the session function.
+
+        Args:
+            name (str): The name of the session.
+            func (function): The session function.
+
+        Returns:
+            nox.sessions.Session: A session object. The object is also
+                automatically added to the manifest.
+        """
+        if not hasattr(func, 'parametrize'):
+            session = Session(name, None, func, self._config, self)
+            self._all_sessions.append(session)
+        else:
+            calls = generate_calls(func, func.parametrize)
+            for call in calls:
+                long_name = name + call.session_signature
+                session = Session(name, long_name, call, self._config, self)
+                self._all_sessions.append(session)
+            if not calls:
+                # Add an empty, do-nothing session.
+                session = Session(
+                    name, None, _null_session_func, self._config, self)
+                self._all_sessions.append(session)
+        return session
+
+    def next(self):
+        return self.__next__()
+
+
+class KeywordLocals(object):
+    """Eval locals using keywords.
+
+    When looking up a local variable the variable name is compared against
+    the set of keywords. If the local variable name matches any *substring* of
+    any keyword, then the name lookup returns True. Otherwise, the name lookup
+    returns False.
+    """
+    def __init__(self, keywords):
+        self._keywords = keywords
+
+    def __getitem__(self, variable_name):
+        for keyword in self._keywords:
+            if variable_name in keyword:
+                return True
+        return False
+
+
+def keyword_match(expression, keywords):
+    """See if an expression matches the given set of keywords."""
+    locals = KeywordLocals(set(keywords))
+    return eval(expression, {}, locals)
+
+
+def _null_session_func(session):
+    """A do-nothing session for patemetrized sessions that have no available
+    parameters."""
+    session.skip('This session had no parameters available.')

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -205,11 +205,12 @@ class SessionConfig(object):
 
 
 class Session(object):
-    def __init__(self, name, signature, func, global_config):
+    def __init__(self, name, signature, func, global_config, manifest=None):
         self.name = name
         self.signature = signature
         self.func = func
         self.global_config = global_config
+        self.manifest = manifest
         self._should_install_deps = True
 
     def _create_config(self):

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -1,0 +1,257 @@
+# Copyright 2017 Jon Wayne Parrott
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, print_function
+
+import imp
+import inspect
+import io
+import json
+import os
+
+import six
+
+from nox import registry
+from nox.logger import logger
+from nox.manifest import Manifest
+
+
+def load_nox_module(global_config):
+    """Load the user's noxfile and return the module object for it.
+
+    .. note::
+
+        This task has two side effects; it makes ``global_config.noxfile``
+        an absolute path, and changes the working directory of the process.
+
+    Args:
+        global_config (.nox.main.GlobalConfig): The global config.
+
+    Returns:
+        module: The module designated by the Noxfile path.
+    """
+    try:
+        # Save the absolute path to the Noxfile.
+        # This will innoculate it if nox changes paths because of an implicit
+        # or explicit chdir (like the one below).
+        global_config.noxfile = os.path.realpath(global_config.noxfile)
+
+        # Move to the path where the Noxfile is.
+        # This will ensure that the Noxfile's path is on sys.path, and that
+        # import-time path resolutions work the way the Noxfile author would
+        # guess.
+        os.chdir(os.path.realpath(os.path.dirname(global_config.noxfile)))
+        return imp.load_source('user_nox_module', global_config.noxfile)
+    except (IOError, OSError):
+        logger.error('Noxfile {} not found.'.format(global_config.noxfile))
+        return 2
+
+
+def discover_manifest(module, global_config):
+    """Discover all session functions in the noxfile module.
+
+    Args:
+        module (module): The Noxfile module.
+        global_config (~nox.main.GlobalConfig): The global configuration.
+
+    Returns:
+        ~.Manifest: A manifest of session functions.
+    """
+    # Find any function added to the session registry (meaning it was
+    # decorated with @nox.session); do not sort these, as they are being
+    # sorted by decorator call time.
+    functions = registry.get()
+
+    # Find any function conforming to the session_* naming convention.
+    # Sort these in alphabetical order.
+    for name in sorted(six.iterkeys(module.__dict__)):
+        obj = module.__dict__[name]
+        if name.startswith('session_') and inspect.isfunction(obj):
+            session_name = name.split('session_', 1).pop()
+            functions[session_name] = obj
+
+    # Return the final dictionary of session functions.
+    return Manifest(functions, global_config)
+
+
+def filter_manifest(manifest, global_config):
+    """Filter the manifest according to the provided configuration.
+
+    Args:
+        manifest (~.Manifest): The manifest of sessions to be run.
+        global_config (~nox.main.GlobalConfig): The global configuration.
+
+    Returns:
+        Union[~.Manifest,int]: ``3`` if a specified session is not found,
+            the manifest otherwise (to be sent to the next task).
+
+    """
+    # Filter by the name of any explicit sessions.
+    # This can raise KeyError if a specified session does not exist;
+    # log this if it happens.
+    if global_config.sessions:
+        try:
+            manifest.filter_by_name(global_config.sessions)
+        except KeyError as exc:
+            logger.error(str(exc))
+            return 3
+
+    # Filter by keywords.
+    # This function never errors, but may cause an empty list of sessions
+    # (which is an error condition later).
+    if global_config.keywords:
+        manifest.filter_by_keywords(global_config.keywords)
+
+    # Return the modified manifest.
+    return manifest
+
+
+def honor_list_request(manifest, global_config):
+    """If --list was passed, simply list the manifest and exit cleanly.
+
+    Args:
+        manifest (~.Manifest): The manifest of sessions to be run.
+        global_config (~nox.main.GlobalConfig): The global configuration.
+
+    Returns:
+        Union[~.Manifest,int]: ``0`` if a listing is all that is requested,
+            the manifest otherwise (to be sent to the next task).
+    """
+    # If the user just asked for a list of sessions, print that
+    # and be done.
+    if global_config.list_sessions:
+        print('Available sessions:')
+        for session in manifest:
+            print('*', session.signature or session.name)
+        return 0
+    return manifest
+
+
+def verify_manifest_nonempty(manifest, global_config):
+    """Abort with an error code if the manifest is empty.
+
+    Args:
+        manifest (~.Manifest): The manifest of sessions to be run.
+        global_config (~nox.main.GlobalConfig): The global configuration.
+
+    Returns:
+        Union[~.Manifest,int]: ``3`` on an empty manifest, the manifest
+            otherwise.
+    """
+    if not manifest:
+        return 3
+    return manifest
+
+
+def run_manifest(manifest, global_config):
+    """Run the full manifest of sessions.
+
+    Args:
+        manifest (~.Manifest): The manifest of sessions to be run.
+        global_config (~nox.main.GlobalConfig): The global configuration.
+
+    Returns:
+        tuple[~nox.sessions.Session,~.SessionStatus]: A two-tuple of the
+            sessions and the result of each session that was run.
+    """
+    results = []
+
+    # Iterate over each session in the manifest, and execute it.
+    #
+    # Note that it is possible for the manifest to be altered in any given
+    # iteration.
+    for session in manifest:
+        result = session.execute()
+        result.log('Session {name} {status}.'.format(
+            name=str(session),
+            status=result.imperfect,
+        ))
+        results.append(result)
+
+        # Sanity check: If we are supposed to stop on the first error case,
+        # the abort now.
+        if not result and global_config.stop_on_first_error:
+            return results
+
+    # The entire manifest has been processed; return the results.
+    return results
+
+
+def print_summary(results, global_config):
+    """Print a summary of the results.
+
+    Args:
+        results (Sequence[~nox.sessions.Result]): A list of Result objects.
+        global_config (~nox.main.GlobalConfig): The global configuration.
+
+    Returns:
+        results (Sequence[~nox.sessions.Result]): The results passed
+            to this function, unmodified.
+    """
+    # Sanity check: Do not print results if there was only one session run.
+    if len(results) <= 1:
+        return results
+
+    # Iterate over the results and print the result for each in a
+    # human-readable way.
+    logger.warning('Ran multiple sessions:')
+    for result in results:
+        result.log('* {name}: {status}'.format(
+            name=str(result.session),
+            status=result.status.name.lower(),
+        ))
+
+    # Return the results that were sent to this function.
+    return results
+
+
+def create_report(results, global_config):
+    """Write a report to the location designated in the config, if any.
+
+    Args:
+        results (Sequence[~nox.sessions.Result]): A list of Result objects
+        global_config (~nox.main.GlobalConfig): The global configuration.
+
+    Returns:
+        results (Sequence[~nox.sessions.Result]): The results passed
+            to this function, unmodified.
+    """
+    # Sanity check: If no JSON report was requested, this is a no-op.
+    if global_config.report is None:
+        return results
+
+    # Write the JSON report.
+    with io.open(global_config.report, 'w') as report_file:
+        json.dump({
+            'result': int(all(results)),
+            'sessions': [result.serialize() for result in results],
+        }, report_file, indent=2)
+
+    # Return back the results passed to this task.
+    return results
+
+
+def final_reduce(results, global_config):
+    """Reduce the results to a final exit code.
+
+    Args:
+        results (Sequence[~nox.sessions.Result]): A list of Result objects
+        global_config (~nox.main.GlobalConfig): The global configuration.
+
+    Returns:
+        int: The final status code; ``0`` for success and ``1`` for failure.
+    """
+    if not all(results):
+        return 1
+    return 0

--- a/nox/utils.py
+++ b/nox/utils.py
@@ -23,6 +23,12 @@ def coerce_str(maybe_str):
 
     This is what is expected for environment variables, where sending a
     unicode on Python 2 or a bytes on Python 3 will raise an exception.
+
+    Args:
+        maybe_str (Union[str,bytes,unicode]): A text or byte string.
+
+    Returns:
+        str: A str literal.
     """
     # If we already have a string, we are done.
     if isinstance(maybe_str, str):

--- a/nox/workflow.py
+++ b/nox/workflow.py
@@ -1,0 +1,54 @@
+# Copyright 2017 Jon Wayne Parrott
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def execute(workflow, global_config):
+    """Execute each function in the workflow.
+
+    Each function in the workflow receives the result of the previous one
+    (if any) and the global configuration.
+
+    If any function returns an integer, it is considered to be an exit code.
+    This means that the iteration of functions is aborted, and the exit code
+    returned immediately.
+
+    This approach promotes testability and separation of concerns.
+
+    Args:
+        workflow (Iterable[function]): The functions to be executed.
+        global_config (~.GlobalConfig): The global configuration, which
+            is passed to each task.
+
+    Returns:
+        int: An exit code.
+    """
+    try:
+        # Iterate over each task and run it.
+        return_value = None
+        for function_ in workflow:
+            # Send the previous task's return value if there was one.
+            args = []
+            if return_value is not None:
+                args.append(return_value)
+            return_value = function_(*args, global_config=global_config)
+
+            # If we got a integer value as a result, abort task processing
+            # and return it.
+            if isinstance(return_value, int):
+                return return_value
+
+        # All tasks completed, presumably without error.
+        return 0
+    except KeyboardInterrupt:
+        return 130  # http://tldp.org/LDP/abs/html/exitcodes.html

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         'virtualenv>=14.0.0'],
 
     extras_require={
-        ':python_version<"3.4"': ['enum34'],
+        ":python_version<'3.4'": ['enum34'],
         'tox_to_nox': ['jinja2', 'tox']
     },
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         'virtualenv>=14.0.0'],
 
     extras_require={
-        ":python_version<'3.4'": ['enum34'],
+        ':python_version<"3.4"': ['enum34'],
         'tox_to_nox': ['jinja2', 'tox']
     },
 

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         'virtualenv>=14.0.0'],
 
     extras_require={
+        ':python_version<"3.4"': ['enum34'],
         'tox_to_nox': ['jinja2', 'tox']
     },
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,23 @@
+# Copyright 2017 Jon Wayne Parrott
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+from nox import logger
+
+
+def test_success():
+    with mock.patch.object(logger.LoggerWithSuccess, '_log') as _log:
+        logger.LoggerWithSuccess('foo').success('bar')
+        _log.assert_called_once_with(logger.SUCCESS, 'bar', ())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,10 +20,10 @@ import mock
 import pkg_resources
 
 import nox
+from nox._testing import Namespace
 import nox.main
 import nox.registry
 import nox.sessions
-from nox._testing import Namespace
 
 
 VERSION = pkg_resources.get_distribution('nox-automation').version

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,28 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
 import os
 import sys
 
 import contexter
 import mock
 import pkg_resources
-import pytest
 
 import nox
 import nox.main
 import nox.registry
 import nox.sessions
+from nox._testing import Namespace
 
 
-RESOURCES = os.path.join(os.path.dirname(__file__), 'resources')
 VERSION = pkg_resources.get_distribution('nox-automation').version
-
-
-class Namespace(object):
-    def __init__(self, **kwargs):
-        self.__dict__.update(kwargs)
 
 
 def test_global_config_constructor():
@@ -64,320 +57,19 @@ def test_global_config_constructor():
     assert config.posargs == ['a', 'b', 'c']
 
 
-def test_load_user_nox_module():
-    noxfile_path = os.path.join(RESOURCES, 'noxfile.py')
-    noxfile_module = nox.main.load_user_nox_module(noxfile_path)
-
-    assert noxfile_module.SIGIL == '123'
-
-
-def test_discover_session_functions_naming_convention():
-    def session_1():
-        pass
-
-    def session_2():
-        pass
-
-    def notasession():
-        pass
-
-    mock_module = Namespace(
-        __name__='irrelevant',
-        session_1=session_1,
-        session_2=session_2,
-        notasession=notasession)
-
-    session_functions = nox.main.discover_session_functions(mock_module)
-
-    assert session_functions == collections.OrderedDict((
-        ('1', session_1),
-        ('2', session_2),
-    ))
-
-
-def test_discover_session_functions_decorator():
-    @nox.session
-    def foo():
-        pass
-
-    @nox.session
-    def bar():
-        pass
-
-    def notasession():
-        pass
-
-    mock_module = Namespace(
-        __name__=foo.__module__,
-        foo=foo,
-        bar=bar,
-        notasession=notasession,
-    )
-    session_functions = nox.main.discover_session_functions(mock_module)
-
-    assert session_functions == collections.OrderedDict((
-        ('foo', foo),
-        ('bar', bar),
-    ))
-
-
-def test_discover_session_functions_mix():
-    @nox.session
-    def foo():
-        pass
-
-    def session_bar():
-        pass
-
-    def notasession():
-        pass
-
-    mock_module = Namespace(
-        __name__=foo.__module__,
-        foo=foo,
-        session_bar=session_bar,
-        notasession=notasession,
-    )
-    session_functions = nox.main.discover_session_functions(mock_module)
-
-    assert session_functions == collections.OrderedDict((
-        ('foo', foo),
-        ('bar', session_bar),
-    ))
-
-
-def test_run(monkeypatch, capsys, tmpdir):
-
-    class MockSession(nox.sessions.Session):
-        def __init__(self, name='session_name', signature=None,
-                     global_config=None, return_value=True):
-            super(MockSession, self).__init__(
-                name, signature, None, global_config)
-            self.execute = mock.Mock()
-            self.execute.return_value = return_value
-
-    global_config = Namespace(
-        noxfile='somefile.py',
-        sessions=None,
-        keywords=None,
-        list_sessions=False,
-        stop_on_first_error=False,
-        posargs=[],
-        report=None,)
-    user_nox_module = mock.Mock()
-    session_functions = {'foo': mock.Mock(), 'bar': mock.Mock()}
-    sessions = [
-        MockSession(),
-        MockSession()
-    ]
-
-    with contexter.ExitStack() as stack:
-        mock_load_user_module = stack.enter_context(mock.patch(
-            'nox.main.load_user_nox_module',
-            side_effect=lambda _: user_nox_module))
-        mock_discover_session_functions = stack.enter_context(mock.patch(
-            'nox.main.discover_session_functions',
-            side_effect=lambda _: session_functions))
-        mock_make_session = stack.enter_context(mock.patch(
-            'nox.manifest.Manifest.make_session', side_effect=[sessions]))
-
-        # Default options
-        result = nox.main.run(global_config)
-        assert result
-
-        # The `load_user_module` function receives an absolute path,
-        # but it should end with the noxfile argument.
-        mock_load_user_module.assert_called_once()
-        _, args, _ = mock_load_user_module.mock_calls[0]
-        assert args[0].endswith('somefile.py')
-
-        mock_discover_session_functions.assert_called_with(user_nox_module)
-        calls = mock_make_session.call_args_list
-        assert len(calls) == 2
-        assert calls[0][0] == ('foo', session_functions['foo'])
-        assert calls[1][0] == ('bar', session_functions['bar'])
-
-        for session in sessions:
-            assert session.execute.called
-            session.execute.reset_mock()
-
-        # List sessions
-        global_config.list_sessions = True
-        result = nox.main.run(global_config)
-        assert result
-
-        out, _ = capsys.readouterr()
-        assert '* session_name' in out
-
-        global_config.list_sessions = False
-
-        # One failing session at the beginning, should still execute all.
-        failing_session = MockSession(return_value=False)
-        sessions.insert(0, failing_session)
-
-        result = nox.main.run(global_config)
-        assert not result
-
-        for session in sessions:
-            assert session.execute.called
-            session.execute.reset_mock()
-
-        # Now it should stop after the first failed session.
-        global_config.stop_on_first_error = True
-
-        result = nox.main.run(global_config)
-        assert not result
-
-        assert sessions[0].execute.called is True
-        assert sessions[1].execute.called is False
-        assert sessions[2].execute.called is False
-
-        for session in sessions:
-            session.execute.reset_mock()
-
-        sessions[0].execute.return_value = True
-
-        # Add a skipped session
-        skipped_session = MockSession(
-            return_value=nox.sessions.SessionStatus.SKIP)
-        sessions.insert(0, skipped_session)
-
-        result = nox.main.run(global_config)
-        assert result
-
-        assert sessions[0].execute.called is True
-        assert sessions[1].execute.called is True
-        assert sessions[2].execute.called is True
-
-        for session in sessions:
-            session.execute.reset_mock()
-
-        # This time it should only run a subset of sessions
-        sessions[0].name = '1'
-        sessions[1].name = '2'
-        sessions[2].name = '3'
-
-        global_config.sessions = ['1', '3']
-
-        result = nox.main.run(global_config)
-        assert result
-
-        assert sessions[0].execute.called is True
-        assert sessions[1].execute.called is False
-        assert sessions[2].execute.called is True
-
-        for session in sessions:
-            session.execute.reset_mock()
-
-        # Try to run with a session that doesn't exist.
-        global_config.sessions = ['1', 'doesntexist']
-
-        result = nox.main.run(global_config)
-        assert not result
-
-        assert sessions[0].execute.called is False
-        assert sessions[1].execute.called is False
-        assert sessions[2].execute.called is False
-
-        for session in sessions:
-            session.execute.reset_mock()
-
-        # Now we'll try with parametrized sessions. Calling the basename
-        # should execute all parametrized versions.
-        sessions[0].name = 'a'
-        sessions[0].signature = 'a(1)'
-        sessions[1].name = 'a'
-        sessions[1].signature = 'a(2)'
-        sessions[2].name = 'b'
-
-        global_config.sessions = ['a']
-
-        result = nox.main.run(global_config)
-        assert result
-
-        assert sessions[0].execute.called is True
-        assert sessions[1].execute.called is True
-        assert sessions[2].execute.called is False
-
-        for session in sessions:
-            session.execute.reset_mock()
-
-        # Calling the signature of should only call one parametrized version.
-        global_config.sessions = ['a(2)']
-
-        result = nox.main.run(global_config)
-        assert result
-
-        assert sessions[0].execute.called is False
-        assert sessions[1].execute.called is True
-        assert sessions[2].execute.called is False
-
-        for session in sessions:
-            session.execute.reset_mock()
-
-        # Calling a signature that does not exist should not call any version.
-        global_config.sessions = ['a(1)', 'a(3)', 'b']
-
-        result = nox.main.run(global_config)
-        assert not result
-
-        assert sessions[0].execute.called is False
-        assert sessions[1].execute.called is False
-        assert sessions[2].execute.called is False
-
-        # Calling a name of an empty parametrized session should work.
-        sessions[:] = [nox.sessions.Session(
-            'name', None, nox.main._null_session_func, global_config)]
-        global_config.sessions = ['name']
-
-        assert nox.main.run(global_config)
-
-        # Using -k should filter sessions
-        sessions[:] = [
-            MockSession('red', 'red()'),
-            MockSession('blue', 'blue()'),
-            MockSession('red', 'red(blue)'),
-            MockSession('redder', 'redder()')]
-        global_config.sessions = None
-        global_config.keywords = 'red and not blue'
-
-        assert nox.main.run(global_config)
-        assert sessions[0].execute.called
-        assert not sessions[1].execute.called
-        assert not sessions[2].execute.called
-        assert sessions[3].execute.called
-
-        global_config.keywords = None
-
-        # Reporting should work
-        report = tmpdir.join('report.json')
-        global_config.report = str(report)
-        assert nox.main.run(global_config)
-        assert report.exists()
-
-        global_config.report = None
-
-        # Summary should fail if there's an invalid status
-        sessions[0].execute.return_value = 2990
-        global_config.sessions = [sessions[0].name]
-        with pytest.raises(ValueError):
-            nox.main.run(global_config)
-
-
-def test_run_file_not_found():
-    global_config = Namespace(
-        noxfile='somefile.py')
-    result = nox.main.run(global_config)
-    assert not result
-
-
-def test_main():
-    # No args
+def test_main_no_args():
     sys.argv = [sys.executable]
-    with mock.patch('nox.main.run') as run_mock:
-        nox.main.main()
-        assert run_mock.called
-        config = run_mock.call_args[0][0]
+    with mock.patch('nox.workflow.execute') as execute:
+        execute.return_value = 0
+
+        # Call the function.
+        with mock.patch.object(sys, 'exit') as exit:
+            nox.main.main()
+            exit.assert_called_once_with(0)
+        assert execute.called
+
+        # Verify that the config looks correct.
+        config = execute.call_args[1]['global_config']
         assert config.noxfile == 'nox.py'
         assert config.envdir.endswith('.nox')
         assert config.sessions is None
@@ -385,18 +77,27 @@ def test_main():
         assert config.stop_on_first_error is False
         assert config.posargs == []
 
-    # Long-form args
+
+def test_main_long_form_args():
     sys.argv = [
         sys.executable,
         '--noxfile', 'noxfile.py',
         '--envdir', '.other',
         '--sessions', '1', '2',
         '--reuse-existing-virtualenvs',
-        '--stop-on-first-error']
-    with mock.patch('nox.main.run') as run_mock:
-        nox.main.main()
-        assert run_mock.called
-        config = run_mock.call_args[0][0]
+        '--stop-on-first-error',
+    ]
+    with mock.patch('nox.workflow.execute') as execute:
+        execute.return_value = 0
+
+        # Call the main function.
+        with mock.patch.object(sys, 'exit') as exit:
+            nox.main.main()
+            exit.assert_called_once_with(0)
+        assert execute.called
+
+        # Verify that the config looks correct.
+        config = execute.call_args[1]['global_config']
         assert config.noxfile == 'noxfile.py'
         assert config.envdir.endswith('.other')
         assert config.sessions == ['1', '2']
@@ -404,55 +105,103 @@ def test_main():
         assert config.stop_on_first_error is True
         assert config.posargs == []
 
-    # Short-form args
+
+def test_main_short_form_args():
     sys.argv = [
         sys.executable,
         '-f', 'noxfile.py',
         '-s', '1', '2',
-        '-r']
-    with mock.patch('nox.main.run') as run_mock:
-        nox.main.main()
-        assert run_mock.called
-        config = run_mock.call_args[0][0]
+        '-r',
+    ]
+    with mock.patch('nox.workflow.execute') as execute:
+        execute.return_value = 0
+
+        # Call the main function.
+        with mock.patch.object(sys, 'exit') as exit:
+            nox.main.main()
+            exit.assert_called_once_with(0)
+        assert execute.called
+
+        # Verify that the config looks correct.
+        config = execute.call_args[1]['global_config']
         assert config.noxfile == 'noxfile.py'
         assert config.sessions == ['1', '2']
         assert config.reuse_existing_virtualenvs is True
 
+
+def test_main_explicit_sessions():
     sys.argv = [
         sys.executable,
-        '-e', '1', '2']
-    with mock.patch('nox.main.run') as run_mock:
-        nox.main.main()
-        assert run_mock.called
-        config = run_mock.call_args[0][0]
+        '-e', '1', '2',
+    ]
+    with mock.patch('nox.workflow.execute') as execute:
+        execute.return_value = 0
+
+        # Call the main function.
+        with mock.patch.object(sys, 'exit') as exit:
+            nox.main.main()
+            exit.assert_called_once_with(0)
+        assert execute.called
+
+        # Verify that the explicit sessions are listed in the config.
+        config = execute.call_args[1]['global_config']
         assert config.sessions == ['1', '2']
 
-    # Posargs
+
+def test_main_positional_args():
     sys.argv = [
         sys.executable,
-        '1', '2', '3']
-    with mock.patch('nox.main.run') as run_mock:
-        nox.main.main()
-        assert run_mock.called
-        config = run_mock.call_args[0][0]
+        '1', '2', '3',
+    ]
+    with mock.patch('nox.workflow.execute') as execute:
+        execute.return_value = 0
+
+        # Call the main function.
+        with mock.patch.object(sys, 'exit') as exit:
+            nox.main.main()
+            exit.assert_called_once_with(0)
+        assert execute.called
+
+        # Verify that the positional args are listed in the config.
+        config = execute.call_args[1]['global_config']
         assert config.posargs == ['1', '2', '3']
 
+
+def test_main_positional_with_double_hyphen():
     sys.argv = [
         sys.executable,
-        '--', '1', '2', '3']
-    with mock.patch('nox.main.run') as run_mock:
-        nox.main.main()
-        assert run_mock.called
-        config = run_mock.call_args[0][0]
+        '--', '1', '2', '3',
+    ]
+    with mock.patch('nox.workflow.execute') as execute:
+        execute.return_value = 0
+
+        # Call the main function.
+        with mock.patch.object(sys, 'exit') as exit:
+            nox.main.main()
+            exit.assert_called_once_with(0)
+        assert execute.called
+
+        # Verify that the positional args are listed in the config.
+        config = execute.call_args[1]['global_config']
         assert config.posargs == ['1', '2', '3']
 
+
+def test_main_positional_flag_like_with_double_hyphen():
     sys.argv = [
         sys.executable,
-        '--', '1', '2', '3', '-f', '--baz']
-    with mock.patch('nox.main.run') as run_mock:
-        nox.main.main()
-        assert run_mock.called
-        config = run_mock.call_args[0][0]
+        '--', '1', '2', '3', '-f', '--baz',
+    ]
+    with mock.patch('nox.workflow.execute') as execute:
+        execute.return_value = 0
+
+        # Call the main function.
+        with mock.patch.object(sys, 'exit') as exit:
+            nox.main.main()
+            exit.assert_called_once_with(0)
+        assert execute.called
+
+        # Verify that the positional args are listed in the config.
+        config = execute.call_args[1]['global_config']
         assert config.posargs == ['1', '2', '3', '-f', '--baz']
 
 
@@ -460,32 +209,19 @@ def test_main_version(capsys):
     sys.argv = [sys.executable, '--version']
 
     with contexter.ExitStack() as stack:
-        run_mock = stack.enter_context(mock.patch('nox.main.run'))
+        execute = stack.enter_context(mock.patch('nox.workflow.execute'))
         exit_mock = stack.enter_context(mock.patch('sys.exit'))
         nox.main.main()
         _, err = capsys.readouterr()
         assert VERSION in err
         exit_mock.assert_not_called()
-        run_mock.assert_not_called()
+        execute.assert_not_called()
 
 
 def test_main_failure():
     sys.argv = [sys.executable]
-
-    with contexter.ExitStack() as stack:
-        run_mock = stack.enter_context(mock.patch('nox.main.run'))
-        exit_mock = stack.enter_context(mock.patch('sys.exit'))
-        run_mock.return_value = False
-        nox.main.main()
-        exit_mock.assert_called_with(1)
-
-
-def test_main_interrupted():
-    sys.argv = [sys.executable]
-
-    with contexter.ExitStack() as stack:
-        run_mock = stack.enter_context(mock.patch('nox.main.run'))
-        exit_mock = stack.enter_context(mock.patch('sys.exit'))
-        run_mock.side_effect = KeyboardInterrupt()
-        nox.main.main()
-        exit_mock.assert_called_with(1)
+    with mock.patch('nox.workflow.execute') as execute:
+        execute.return_value = 1
+        with mock.patch.object(sys, 'exit') as exit:
+            nox.main.main()
+            exit.assert_called_once_with(1)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,190 @@
+# Copyright 2017 Jon Wayne Parrott
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+
+import mock
+import pytest
+
+import nox
+from nox.manifest import _null_session_func
+from nox.manifest import Manifest
+
+
+def create_mock_sessions():
+    sessions = collections.OrderedDict()
+    sessions['foo'] = mock.Mock(spec=())
+    sessions['bar'] = mock.Mock(spec=())
+    return sessions
+
+
+def test_init():
+    sessions = create_mock_sessions()
+    manifest = Manifest(sessions, mock.sentinel.CONFIG)
+
+    # Assert that basic properties look correctly.
+    assert len(manifest) == 2
+    assert manifest['foo'].func is sessions['foo']
+    assert manifest['bar'].func is sessions['bar']
+
+
+def test_contains():
+    sessions = create_mock_sessions()
+    manifest = Manifest(sessions, mock.sentinel.CONFIG)
+
+    # Establish that contains works pre-iteration.
+    assert 'foo' in manifest
+    assert 'bar' in manifest
+    assert 'baz' not in manifest
+
+    # Establish that __contains__ works post-iteration.
+    for session in manifest:
+        pass
+    assert 'foo' in manifest
+    assert 'bar' in manifest
+    assert 'baz' not in manifest
+
+    # Establish that sessions themselves work.
+    assert manifest['foo'] in manifest
+
+
+def test_getitem():
+    sessions = create_mock_sessions()
+    manifest = Manifest(sessions, mock.sentinel.CONFIG)
+
+    # Establish that each session is present, and a made-up session
+    # is not.
+    assert manifest['foo'].func is sessions['foo']
+    assert manifest['bar'].func is sessions['bar']
+    with pytest.raises(KeyError):
+        manifest['baz']
+
+    # Establish that the sessions are still present even after being
+    # consumed by iteration.
+    for session in manifest:
+        pass
+    assert manifest['foo'].func is sessions['foo']
+    assert manifest['bar'].func is sessions['bar']
+
+
+def test_iteration():
+    sessions = create_mock_sessions()
+    manifest = Manifest(sessions, mock.sentinel.CONFIG)
+
+    # There should be two sessions in the queue.
+    assert len(manifest._queue) == 2
+    assert len(manifest._consumed) == 0
+
+    # The first item should be our "foo" session.
+    foo = next(manifest)
+    assert foo.func == sessions['foo']
+    assert foo in manifest._consumed
+    assert foo not in manifest._queue
+    assert len(manifest._consumed) == 1
+    assert len(manifest._queue) == 1
+
+    # The .next() or .__next__() methods can be called directly according
+    # to Python's data model.
+    bar = manifest.next()
+    assert bar.func == sessions['bar']
+    assert bar in manifest._consumed
+    assert bar not in manifest._queue
+    assert len(manifest._consumed) == 2
+    assert len(manifest._queue) == 0
+
+    # Continuing past the end raises StopIteration.
+    with pytest.raises(StopIteration):
+        manifest.__next__()
+
+
+def test_len():
+    sessions = create_mock_sessions()
+    manifest = Manifest(sessions, mock.sentinel.CONFIG)
+    assert len(manifest) == 2
+    for session in manifest:
+        assert len(manifest) == 2
+
+
+def test_filter_by_name():
+    sessions = create_mock_sessions()
+    manifest = Manifest(sessions, mock.sentinel.CONFIG)
+    manifest.filter_by_name(('foo',))
+    assert 'foo' in manifest
+    assert 'bar' not in manifest
+
+
+def test_filter_by_name_not_found():
+    sessions = create_mock_sessions()
+    manifest = Manifest(sessions, mock.sentinel.CONFIG)
+    with pytest.raises(KeyError):
+        manifest.filter_by_name(('baz',))
+
+
+def test_filter_by_keyword():
+    sessions = create_mock_sessions()
+    manifest = Manifest(sessions, mock.sentinel.CONFIG)
+    assert len(manifest) == 2
+    manifest.filter_by_keywords('foo or bar')
+    assert len(manifest) == 2
+    manifest.filter_by_keywords('foo')
+    assert len(manifest) == 1
+
+
+def test_add_session_plain():
+    manifest = Manifest({}, mock.sentinel.CONFIG)
+    for session in manifest.make_session('my_session', lambda session: None):
+        manifest.add_session(session)
+    assert len(manifest) == 1
+
+
+def test_add_session_parametrized():
+    manifest = Manifest({}, mock.sentinel.CONFIG)
+
+    # Define a session with parameters.
+    @nox.parametrize('param', ('a', 'b', 'c'))
+    def my_session(session, param):
+        pass
+
+    # Add the session to the manifest.
+    for session in manifest.make_session('my_session', my_session):
+        manifest.add_session(session)
+    assert len(manifest) == 3
+
+
+def test_add_session_parametrized_noop():
+    manifest = Manifest({}, mock.sentinel.CONFIG)
+
+    # Define a session without any parameters.
+    @nox.parametrize('param', ())
+    def my_session(session, param):
+        pass
+
+    # Add the session to the manifest.
+    for session in manifest.make_session('my_session', my_session):
+        manifest.add_session(session)
+    assert len(manifest) == 1
+
+
+def test_add_session_idempotent():
+    manifest = Manifest({}, mock.sentinel.CONFIG)
+    for session in manifest.make_session('my_session', lambda session: None):
+        manifest.add_session(session)
+        manifest.add_session(session)
+    assert len(manifest) == 1
+
+
+def test_null_session_function():
+    session = mock.Mock(spec=('skip',))
+    _null_session_func(session)
+    assert session.skip.called

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -18,11 +18,11 @@ import mock
 
 import pytest
 
+from nox._testing import Namespace
 import nox.command
+from nox.logger import logger
 import nox.sessions
 import nox.virtualenv
-from nox._testing import Namespace
-from nox.logger import logger
 
 
 def test__normalize_path():

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,310 @@
+# Copyright 2017 Jon Wayne Parrott
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import io
+import json
+import os
+
+import mock
+
+import nox
+from nox import sessions
+from nox import tasks
+from nox._testing import Namespace
+from nox.manifest import Manifest
+
+
+RESOURCES = os.path.join(os.path.dirname(__file__), 'resources')
+
+
+def test_load_nox_module():
+    config = Namespace(noxfile=os.path.join(RESOURCES, 'noxfile.py'))
+    noxfile_module = tasks.load_nox_module(config)
+    assert noxfile_module.SIGIL == '123'
+
+
+def test_load_nox_module_not_found():
+    config = Namespace(noxfile='bogus.py')
+    assert tasks.load_nox_module(config) == 2
+
+
+def test_discover_manifest_naming_convention():
+    # Define sessions with the correct naming convention.
+    def session_1():
+        pass
+
+    def session_2():
+        pass
+
+    def notasession():
+        pass
+
+    # Mock up a nox.py module and configuration.
+    mock_module = Namespace(
+        __name__='irrelevant',
+        session_1=session_1,
+        session_2=session_2,
+        notasession=notasession,
+    )
+    config = Namespace(sessions=(), keywords=())
+
+    # Get the manifest and establish that it looks like what we expect.
+    manifest = tasks.discover_manifest(mock_module, config)
+    sessions = list(manifest)
+    assert [s.func for s in sessions] == [session_1, session_2]
+    assert [str(i) for i in sessions] == ['1', '2']
+
+
+def test_discover_session_functions_decorator():
+    # Define sessions using the decorator.
+    @nox.session
+    def foo():
+        pass
+
+    @nox.session
+    def bar():
+        pass
+
+    def notasession():
+        pass
+
+    # Mock up a nox.py module and configuration.
+    mock_module = Namespace(
+        __name__=foo.__module__,
+        foo=foo,
+        bar=bar,
+        notasession=notasession,
+    )
+    config = Namespace(sessions=(), keywords=())
+
+    # Get the manifest and establish that it looks like what we expect.
+    manifest = tasks.discover_manifest(mock_module, config)
+    sessions = list(manifest)
+    assert [s.func for s in sessions] == [foo, bar]
+    assert [str(i) for i in sessions] == ['foo', 'bar']
+
+
+def test_discover_session_functions_mix():
+    # Define sessions using both mechanisms.
+    @nox.session
+    def foo():
+        pass
+
+    def session_bar():
+        pass
+
+    def notasession():
+        pass
+
+    # Mock up a nox.py module and configuration.
+    mock_module = Namespace(
+        __name__=foo.__module__,
+        foo=foo,
+        session_bar=session_bar,
+        notasession=notasession,
+    )
+    config = Namespace(sessions=(), keywords=())
+
+    # Get the manifest and establish that it looks like what we expect.
+    manifest = tasks.discover_manifest(mock_module, config)
+    sessions = list(manifest)
+    assert [s.func for s in sessions] == [foo, session_bar]
+    assert [str(i) for i in sessions] == ['foo', 'bar']
+
+
+def test_filter_manifest():
+    config = Namespace(sessions=(), keywords=())
+    manifest = Manifest({
+        'foo': mock.Mock(spec=()),
+        'bar': mock.Mock(spec=()),
+    }, config)
+    return_value = tasks.filter_manifest(manifest, config)
+    assert return_value is manifest
+    assert len(manifest) == 2
+
+
+def test_filter_manifest_not_found():
+    config = Namespace(sessions=('baz',), keywords=())
+    manifest = Manifest({
+        'foo': mock.Mock(spec=()),
+        'bar': mock.Mock(spec=()),
+    }, config)
+    return_value = tasks.filter_manifest(manifest, config)
+    assert return_value == 3
+
+
+def test_filter_manifest_keywords():
+    config = Namespace(sessions=(), keywords='foo or bar')
+    manifest = Manifest({
+        'foo': mock.Mock(spec=()),
+        'bar': mock.Mock(spec=()),
+        'baz': mock.Mock(spec=()),
+    }, config)
+    return_value = tasks.filter_manifest(manifest, config)
+    assert return_value is manifest
+    assert len(manifest) == 2
+
+
+def test_honor_list_request_noop():
+    config = Namespace(list_sessions=False)
+    manifest = {'thing': mock.sentinel.THING}
+    return_value = tasks.honor_list_request(manifest, global_config=config)
+    assert return_value is manifest
+
+
+def test_honor_list_request():
+    config = Namespace(list_sessions=True)
+    manifest = [Namespace(signature='foo')]
+    return_value = tasks.honor_list_request(manifest, global_config=config)
+    assert return_value == 0
+
+
+def test_verify_manifest_empty():
+    config = Namespace(sessions=(), keywords=())
+    manifest = Manifest({}, config)
+    return_value = tasks.verify_manifest_nonempty(
+        manifest,
+        global_config=config,
+    )
+    assert return_value == 3
+
+
+def test_verify_manifest_nonempty():
+    config = Namespace(sessions=(), keywords=())
+    manifest = Manifest({'session': lambda session: None}, config)
+    return_value = tasks.verify_manifest_nonempty(
+        manifest,
+        global_config=config,
+    )
+    assert return_value == manifest
+
+
+def test_run_manifest():
+    # Set up a valid manifest.
+    config = Namespace(stop_on_first_error=False)
+    sessions_ = [
+        mock.Mock(spec=sessions.Session),
+        mock.Mock(spec=sessions.Session),
+    ]
+    manifest = Manifest({}, config)
+    manifest._queue = copy.copy(sessions_)
+
+    # Ensure each of the mocks returns a successful result
+    for mock_session in sessions_:
+        mock_session.execute.return_value = sessions.Result(
+            session=mock_session,
+            status=sessions.Status.SUCCESS,
+        )
+
+    # Run the manifest.
+    results = tasks.run_manifest(manifest, global_config=config)
+
+    # Verify the results look correct.
+    assert len(results) == 2
+    assert results[0].session == sessions_[0]
+    assert results[1].session == sessions_[1]
+    for result in results:
+        assert isinstance(result, sessions.Result)
+        assert result.status == sessions.Status.SUCCESS
+
+
+def test_run_manifest_abort_on_first_failure():
+    # Set up a valid manifest.
+    config = Namespace(stop_on_first_error=True)
+    sessions_ = [
+        mock.Mock(spec=sessions.Session),
+        mock.Mock(spec=sessions.Session),
+    ]
+    manifest = Manifest({}, config)
+    manifest._queue = copy.copy(sessions_)
+
+    # Ensure each of the mocks returns a successful result.
+    for mock_session in sessions_:
+        mock_session.execute.return_value = sessions.Result(
+            session=mock_session,
+            status=sessions.Status.FAILED,
+        )
+
+    # Run the manifest.
+    results = tasks.run_manifest(manifest, global_config=config)
+
+    # Verify the results look correct.
+    assert len(results) == 1
+    assert isinstance(results[0], sessions.Result)
+    assert results[0].session == sessions_[0]
+    assert results[0].status == sessions.Status.FAILED
+
+    # Verify that only the first session was called.
+    assert sessions_[0].execute.called
+    assert not sessions_[1].execute.called
+
+
+def test_print_summary_one_result():
+    results = [mock.sentinel.RESULT]
+    with mock.patch('nox.tasks.logger', autospec=True) as logger:
+        answer = tasks.print_summary(results, object())
+        assert not logger.warning.called
+        assert not logger.success.called
+        assert not logger.error.called
+    assert answer is results
+
+
+def test_print_summary():
+    results = [
+        sessions.Result(session='foo', status=sessions.Status.SUCCESS),
+        sessions.Result(session='bar', status=sessions.Status.FAILED),
+    ]
+    with mock.patch.object(sessions.Result, 'log', autospec=True) as log:
+        answer = tasks.print_summary(results, object())
+        assert log.call_count == 2
+    assert answer is results
+
+
+def test_create_report_noop():
+    config = Namespace(report=None)
+    with mock.patch.object(io, 'open', autospec=True) as open_:
+        results = tasks.create_report(mock.sentinel.RESULTS, config)
+        assert not open_.called
+    assert results is mock.sentinel.RESULTS
+
+
+def test_create_report():
+    config = Namespace(report='/path/to/report')
+    results = [sessions.Result(
+        session=Namespace(signature='foosig', name='foo', func=object()),
+        status=sessions.Status.SUCCESS,
+    )]
+    with mock.patch.object(io, 'open', autospec=True) as open_:
+        with mock.patch.object(json, 'dump', autospec=True) as dump:
+            answer = tasks.create_report(results, config)
+            assert answer is results
+            dump.assert_called_once_with({
+                'result': 1,
+                'sessions': [{
+                    'name': 'foo',
+                    'signature': 'foosig',
+                    'result': 'success',
+                    'result_code': 1,
+                    'args': {},
+                }],
+            }, mock.ANY, indent=2)
+        open_.assert_called_once_with('/path/to/report', 'w')
+
+
+def test_final_reduce():
+    config = object()
+    assert tasks.final_reduce([True, True], config) == 0
+    assert tasks.final_reduce([True, False], config) == 1
+    assert tasks.final_reduce([], config) == 0

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,103 @@
+# Copyright 2017 Jon Wayne Parrott
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+from nox import workflow
+
+
+def test_simple_workflow():
+    # Set up functions for the workflow.
+    function_a = mock.Mock(spec=())
+    function_b = mock.Mock(spec=())
+    function_c = mock.Mock(spec=())
+
+    # Execute the workflow.
+    exit_code = workflow.execute(
+        workflow=(function_a, function_b, function_c),
+        global_config=mock.sentinel.CONFIG,
+    )
+
+    # There were no errors; the final exit code should be 0.
+    assert exit_code == 0
+
+    # Each function should have been called with the previous one's
+    # return value.
+    function_a.assert_called_once_with(global_config=mock.sentinel.CONFIG)
+    function_b.assert_called_once_with(
+        function_a.return_value,
+        global_config=mock.sentinel.CONFIG,
+    )
+    function_c.assert_called_once_with(
+        function_b.return_value,
+        global_config=mock.sentinel.CONFIG,
+    )
+
+
+def test_workflow_int_cutoff():
+    # Set up functions for the workflow.
+    function_a = mock.Mock(spec=())
+    function_b = mock.Mock(spec=())
+    function_c = mock.Mock(spec=())
+
+    # This time, function_b will stop the process by returning an exit
+    # code outright.
+    function_b.return_value = 42
+
+    # Execute the workflow.
+    exit_code = workflow.execute(
+        workflow=(function_a, function_b, function_c),
+        global_config=mock.sentinel.CONFIG,
+    )
+
+    # There were no errors; the final exit code should be 0.
+    assert exit_code == 42
+
+    # Each function should have been called with the previous one's
+    # return value.
+    function_a.assert_called_once_with(global_config=mock.sentinel.CONFIG)
+    function_b.assert_called_once_with(
+        function_a.return_value,
+        global_config=mock.sentinel.CONFIG,
+    )
+    assert not function_c.called
+
+
+def test_workflow_interrupted():
+    # Set up functions for the workflow.
+    function_a = mock.Mock(spec=())
+    function_b = mock.Mock(spec=())
+    function_c = mock.Mock(spec=())
+
+    # This time, function_b will stop the process by returning an exit
+    # code outright.
+    function_b.side_effect = KeyboardInterrupt
+
+    # Execute the workflow.
+    exit_code = workflow.execute(
+        workflow=(function_a, function_b, function_c),
+        global_config=mock.sentinel.CONFIG,
+    )
+
+    # There were no errors; the final exit code should be 0.
+    assert exit_code == 130
+
+    # Each function should have been called with the previous one's
+    # return value.
+    function_a.assert_called_once_with(global_config=mock.sentinel.CONFIG)
+    function_b.assert_called_once_with(
+        function_a.return_value,
+        global_config=mock.sentinel.CONFIG,
+    )
+    assert not function_c.called


### PR DESCRIPTION
Greetings.

I have a proposed refactoring that I would like to do (mostly done actually) regarding how nox comes up with its session list.

### The Status Quo

Right now, the `main` function discovers sessions based on the Noxfile, filters them based on CLI arguments, ends up with a `list`, and then does a simple loop over that list and executes them in order.

### Proposal

I want to refactor how nox stores its session list into a somewhat more powerful "manifest" class, implemented in this PR (`manifest.py`). The manifest takes the original list of functions that comes back from `discover_session_functions` and applies all the filters as before.

_Iterating_ over the manifest is slightly different, in an extremely important way. Internally, the manifest keeps a queue (a list of sessions yet to be yielded) and a consumed list (a list of sessions already yielded). Importantly, _this allows the queue of remaining sessions to be modified during iteration_.

### Why do I want this?

Basically, I want to be able to add a session to the queue from another session. In particular, I want to implement something similar to handlers in Ansible, so I could do something like this...

```python
@nox.session
@nox.parametrize(version=('2.7', '3.6'))
def unit_tests(session, version):
    # Run the unit tests
    cover.notify()   # <-- THIS IS THE IMPORTANT PART. :-)

@nox.session
@nox.parametrize(version=('2.7', '3.6'))
def system_tests(session, version):
    # Run the system tests

@nox.session
def docs(session):
    # Build the docs.

@nox.session
def lint(session):
    # Lint all the things.

@nox.session
def cover(session):
    # All the .coverage files were written by unit_test earlier.
    session.install('coverage')
    session.run('coverage', 'report', '--fail-under=100')
    session.run('coverage', 'erase')
```

I want this because right now I find myself issuing `nox -s "unit_tests(version='3.6')" ; nox -s cover` _a lot_. Really what I want is I always want cover to run if _any_ of the sessions that wrote out coverage data ran.

Obviously not everyone will want this, but I hope in principle you can see how this is a useful feature. :-)

### Conclusion

This does not yet implement the notify feature (although it becomes easy once the manifest is a thing). However, is this something you are willing to accept in principle?

The manifest code is there and works, I would just need to update tests (but `test_run` is kind of gnarly and I wanted to get design approval before I spent an hour adapting all the mocks and such).