### PR TITLE
Addition of session.notify

### DIFF
--- a/nox.py
+++ b/nox.py
@@ -22,7 +22,8 @@ def default(session):
     tests = session.posargs or ['tests/']
     session.run(
         'py.test', '--cov=nox', '--cov-config', '.coveragerc',
-        '--cov-report', 'term-missing', *tests)
+        '--cov-report=', *tests)
+    session.notify('cover')
 
 
 @nox.session
@@ -30,6 +31,13 @@ def default(session):
 def interpreters(session, version):
     default(session)
     session.interpreter = 'python' + version
+
+
+@nox.session
+def cover(session):
+    session.install('coverage')
+    session.run('coverage', 'report', '--fail-under=100', '--show-missing')
+    session.run('coverage', 'erase')
 
 
 @nox.session

--- a/nox/command.py
+++ b/nox/command.py
@@ -60,7 +60,7 @@ class Command(object):
         self.path = path
         self.success_codes = success_codes or [0]
 
-    def run(self, path_override=None, env_fallback=None):
+    def run(self, path_override=None, env_fallback=None, **kwargs):
         path = self.path if path_override is None else path_override
 
         env = env_fallback.copy() if env_fallback is not None else None
@@ -169,3 +169,15 @@ class InstallCommand(object):
 
     def __str__(self):
         return ' '.join(self.deps)
+
+
+class NotifyCommand(Command):
+    """Notify the given session and add it to the queue."""
+
+    def __init__(self, target, debug=False):
+        self.target = target
+        self.debug = debug
+
+    def __call__(self, session, **kwargs):
+        logger.info('Notifying session: %s' % self.target)
+        session.manifest.notify(self.target)

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -164,6 +164,37 @@ class Manifest(object):
     def next(self):
         return self.__next__()
 
+    def notify(self, session):
+        """Enqueue the specified session in the queue.
+
+        If the session is already in the queue, or has been run already,
+        then this is a no-op.
+
+        Args:
+            session (Union[str, ~nox.session.Session]): The session to be
+                enqueued.
+
+        Returns:
+            bool: Whether the session was added to the queue.
+
+        Raises:
+            ValueError: If the session was not found.
+        """
+        # Sanity check: If this session is already in the queue, this is
+        # a no-op.
+        if session in self:
+            return False
+
+        # Locate the session in the list of all sessions, and place it at
+        # the end of the queue.
+        for s in self._all_sessions:
+            if s == session or s.name == session or s.signature == session:
+                self._queue.append(s)
+                return True
+
+        # The session was not found in the list of sessions.
+        raise ValueError('Session %s not found.' % session)
+
 
 class KeywordLocals(object):
     """Eval locals using keywords.

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -22,8 +22,12 @@ import py
 import six
 
 from nox import utils
-from nox.command import (
-    ChdirCommand, Command, CommandFailed, FunctionCommand, InstallCommand)
+from nox.command import ChdirCommand
+from nox.command import Command
+from nox.command import CommandFailed
+from nox.command import FunctionCommand
+from nox.command import InstallCommand
+from nox.command import NotifyCommand
 from nox.logger import logger
 from nox.virtualenv import ProcessEnv, VirtualEnv
 
@@ -190,6 +194,19 @@ class SessionConfig(object):
             raise ValueError('At least one argument required to install().')
         self._commands.append(InstallCommand(args))
 
+    def notify(self, target):
+        """Place the given session at the end of the queue.
+
+        This method is idempotent; multiple notifications to the same session
+        have no effect.
+
+        Args:
+            target (Union[str|Callable]): The session to be notified. This
+                may be specified as the appropropriate string or using
+                the function object.
+        """
+        self._commands.append(NotifyCommand(target))
+
     def log(self, *args, **kwargs):
         """Outputs a log during the session."""
         logger.info(*args, **kwargs)
@@ -255,7 +272,10 @@ class Session(object):
         for command in self.config._commands:
             if isinstance(command, Command):
                 command(
-                    path_override=self.venv.bin, env_fallback=env)
+                    env_fallback=env,
+                    path_override=self.venv.bin,
+                    session=self,
+                )
             elif isinstance(command, InstallCommand):
                 if not self._should_install_deps:
                     logger.debug(

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -201,7 +201,7 @@ class SessionConfig(object):
         have no effect.
 
         Args:
-            target (Union[str|Callable]): The session to be notified. This
+            target (Union[str, Callable]): The session to be notified. This
                 may be specified as the appropropriate string or using
                 the function object.
         """

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -256,3 +256,10 @@ def test_function_command_debug(make_one_func):
 
     assert command.run()
     mock_func.assert_called_with(1, two=3)
+
+
+def test_notify_command():
+    command = nox.command.NotifyCommand('foo')
+    m = mock.Mock()
+    command(m)
+    m.manifest.notify.assert_called_once_with('foo')

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -85,6 +85,13 @@ def test_config_chdir(make_one_config):
     assert str(command) == 'chdir meep'
 
 
+def test_config_notify(make_one_config):
+    config = make_one_config()
+    config.notify('foo')
+    command = config._commands[0]
+    assert isinstance(command, nox.command.NotifyCommand)
+
+
 def test_config_run(make_one_config):
     def test_func():
         pass


### PR DESCRIPTION
This adds the `session.notify` command, exemplified in nox's own `nox.py` module, where any of the four interpreters trigger the `cover` session.