### PR TITLE
Fix nox not returning a non-zero exit code on failure

### DIFF
--- a/nox/main.py
+++ b/nox/main.py
@@ -102,6 +102,7 @@ def main():
             tasks.honor_list_request,
             tasks.verify_manifest_nonempty,
             tasks.run_manifest,
+            tasks.final_reduce,
         ),
     )
 


### PR DESCRIPTION
Resolves #54