### PR TITLE
Adding None-check to `locate_via_py`.

### DIFF
--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -70,10 +70,17 @@ def locate_via_py(version):
     version. We then make the python process print out its full
     executable path which we use as the location for the version-
     specific Python interpreter.
+
+    Args:
+        version (str): The desired Python version.
+
+    Returns:
+        Optional[str]: The full executable path for the Python ``version``,
+        if it is found.
     """
-    script = "import sys; print(sys.executable)"
+    script = 'import sys; print(sys.executable)'
     py_exe = py.path.local.sysfind('py')
-    if py_exe:
+    if py_exe is not None:
         try:
             return py_exe.sysexec('-' + version, '-c', script).strip()
         except py.process.cmdexec.Error:

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -219,7 +219,7 @@ def test__resolved_interpreter_windows_full_path(make_one):
     with mock.patch.object(platform, 'system') as system:
         system.return_value = 'Windows'
         with mock.patch.object(py.path.local, 'sysfind') as sysfind:
-            sysfind.return_value = True
+            sysfind.return_value = py.path.local(venv.interpreter)
             assert venv._resolved_interpreter == r'c:\Python36\python.exe'
             system.assert_called_once_with()
             sysfind.assert_called_once_with(r'c:\Python36\python.exe')
@@ -286,7 +286,7 @@ def test__resolved_interpreter_not_found(sysfind, check, system, make_one):
 
     # We are on Windows, and nothing can be found.
     system.return_value = 'Windows'
-    sysfind.return_value = False
+    sysfind.return_value = None
     check.return_value = False
 
     # Run the test.


### PR DESCRIPTION
Follow-up to #53. Also

- Using single quotes instead of double quotes
- Adding Args/Returns section to docstring