### PR TITLE
Fixing tox-to-nox docs reference.

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -119,9 +119,9 @@ Converting from tox
 
 Nox has experimental support for converting ``tox.ini`` files into ``nox.py`` files. This doesn't support every feature of tox and is intended to just do most of the mechanical work of converting over- you'll likely still need to make a few changes to the converted ``nox.py``.
 
-To use the converter, install ``nox`` with the ``tox-to-nox`` extra::
+To use the converter, install ``nox`` with the ``tox_to_nox`` extra::
 
-    pip install --upgrade nox-automation[tox-to-nox]
+    pip install --upgrade nox-automation[tox_to_nox]
 
 Then, just run ``tox-to-nox`` in the directory where your ``tox.ini`` resides::
 

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import itertools
 
 from nox._parametrize import generate_calls

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -15,7 +15,6 @@
 import os
 
 import mock
-
 import pytest
 
 from nox._testing import Namespace


### PR DESCRIPTION
The extra is actually `tox_to_nox`, not `tox-to-nox`. Another acceptable way to "fix" this probably would be to rename the extra.