### PR TITLE
Simulating `unittest.mock` backport in the Python 2 standard library.

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 flask
-mock
+mock; python_version < '3'
 pytest
 pytest-cov
 contexter

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Jon Wayne Parrott
+# Copyright 2018 Jon Wayne Parrott
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest import mock
+"""py.test shared testing configuration.
 
-from nox import logger
+This monkey-patches ``mock`` as ``unittest.mock`` for Python 2.7.
+"""
+
+import sys
+import unittest
+
+import six
 
 
-def test_success():
-    with mock.patch.object(logger.LoggerWithSuccess, '_log') as _log:
-        logger.LoggerWithSuccess('foo').success('bar')
-        _log.assert_called_once_with(logger.SUCCESS, 'bar', ())
+if six.PY2:
+    import mock  # pylint: disable=import-error
+    unittest.mock = mock
+    sys.modules['unittest.mock'] = unittest.mock

--- a/tests/test__parametrize.py
+++ b/tests/test__parametrize.py
@@ -1,4 +1,18 @@
-import mock
+# Copyright 2016 Jon Wayne Parrott
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
 
 from nox import _parametrize
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -14,8 +14,8 @@
 
 import os
 import sys
+from unittest import mock
 
-import mock
 import pytest
 
 import nox.command

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,9 +14,9 @@
 
 import os
 import sys
+from unittest import mock
 
 import contexter
-import mock
 import pkg_resources
 
 import nox

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import collections
+from unittest import mock
 
-import mock
 import pytest
 
 import nox

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import os
+from unittest import mock
 
-import mock
 import pytest
 
 from nox._testing import Namespace

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -16,8 +16,7 @@ import copy
 import io
 import json
 import os
-
-import mock
+from unittest import mock
 
 import nox
 from nox import sessions

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -248,7 +248,7 @@ def test__resolved_interpreter_windows_pyexe(sysfind, system, make_one):
     assert venv._resolved_interpreter == r'c:\python36\python.exe'
     sysfind.assert_any_call('python3.6')
     sysfind.assert_any_call('py')
-    system.assert_called()
+    system.assert_called_with()
 
 
 @mock.patch.object(platform, 'system')
@@ -273,7 +273,7 @@ def test__resolved_interpreter_windows_pyexe_fails(sysfind, system, make_one):
         venv._resolved_interpreter
     sysfind.assert_any_call('python3.6')
     sysfind.assert_any_call('py')
-    system.assert_called()
+    system.assert_called_with()
 
 
 @mock.patch.object(platform, 'system')

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -14,8 +14,8 @@
 
 import os
 import platform
+from unittest import mock
 
-import mock
 import py
 import pytest
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
 
 from nox import workflow
 


### PR DESCRIPTION
Also sneaking in a missing license header on a file (I verified in the `git` history that the file is from 2016).